### PR TITLE
modify the way to retrieve IDs of AZs in the region.

### DIFF
--- a/server/lib/shared-infra/shared-infra-stack.ts
+++ b/server/lib/shared-infra/shared-infra-stack.ts
@@ -3,7 +3,7 @@ import * as path from 'path';
 import * as elbv2 from 'aws-cdk-lib/aws-elasticloadbalancingv2';
 import * as targets from 'aws-cdk-lib/aws-elasticloadbalancingv2-targets';
 import { type Construct } from 'constructs';
-import { Stack, type StackProps, type Environment, Tags, CfnOutput } from 'aws-cdk-lib';
+import { Stack, type StackProps, type Environment, Tags, CfnOutput, Fn } from 'aws-cdk-lib';
 import { StringParameter } from 'aws-cdk-lib/aws-ssm';
 import { ApiGateway } from './api-gateway';
 import { type ApiKeySSMParameterNames } from '../interfaces/api-key-ssm-parameter-names';
@@ -33,11 +33,17 @@ export class SharedInfraStack extends Stack {
 
   constructor (scope: Construct, id: string, props: SharedInfraProps) {
     super(scope, id);
+    
+    const azs = Fn.getAzs(this.region);
 
     this.vpc = new ec2.Vpc(this, 'sbt-ecs-vpc', {
       // maxAzs: 3,
       ipAddresses: ec2.IpAddresses.cidr('10.0.0.0/16'),
-      availabilityZones: [`${props.env.region}a`, `${props.env.region}b`, `${props.env.region}c`],
+      availabilityZones: [
+        Fn.select(0, azs),
+        Fn.select(1, azs),
+        Fn.select(2, azs),
+      ],
       flowLogs: {
         'sbt-ecs-vpcFlowLog': {
           destination: ec2.FlowLogDestination.toCloudWatchLogs(),


### PR DESCRIPTION
*Issue #, if available:*
In shared-infra-stack.ts, the IDs of AZs are fixed as a, b and c.
In the region like Tokyo (ap-northeast-1), AZ-b is not available anymore, which cases deploy error.

*Description of changes:*
I made a change with shared-infra-stack.ts.

1. Import Fn module.
2. Add the code to retrieve AZs available in a region.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
