### PR TITLE
fix: Only Supported Availability Zone is used

### DIFF
--- a/server/bin/ecs-saas-ref-template.ts
+++ b/server/bin/ecs-saas-ref-template.ts
@@ -144,13 +144,3 @@ tenantTemplateStack.addDependency(sharedInfraStack);
 cdk.Tags.of(tenantTemplateStack).add('TenantId', tenantId);
 cdk.Tags.of(tenantTemplateStack).add('IsPooledDeploy', String(isPooledDeploy));
 cdk.Aspects.of(tenantTemplateStack).add(new DestroyPolicySetter());
-
-// const ecsSaaSPipeline = new TenantUpdatePipeline(app, 'tenant-update-stack', {
-//   tenantMappingTable: coreAppPlaneStack.tenantMappingTable,
-//   codeCommitRepositoryName: codeCommitRepositoryName,
-//   env: {
-//     account: process.env.CDK_DEFAULT_ACCOUNT,
-//     region: process.env.CDK_DEFAULT_REGION
-//   }
-// });
-// cdk.Aspects.of(ecsSaaSPipeline).add(new DestroyPolicySetter());

--- a/server/bin/ecs-saas-ref-template.ts
+++ b/server/bin/ecs-saas-ref-template.ts
@@ -145,12 +145,12 @@ cdk.Tags.of(tenantTemplateStack).add('TenantId', tenantId);
 cdk.Tags.of(tenantTemplateStack).add('IsPooledDeploy', String(isPooledDeploy));
 cdk.Aspects.of(tenantTemplateStack).add(new DestroyPolicySetter());
 
-const ecsSaaSPipeline = new TenantUpdatePipeline(app, 'tenant-update-stack', {
-  tenantMappingTable: coreAppPlaneStack.tenantMappingTable,
-  codeCommitRepositoryName: codeCommitRepositoryName,
-  env: {
-    account: process.env.CDK_DEFAULT_ACCOUNT,
-    region: process.env.CDK_DEFAULT_REGION
-  }
-});
-cdk.Aspects.of(ecsSaaSPipeline).add(new DestroyPolicySetter());
+// const ecsSaaSPipeline = new TenantUpdatePipeline(app, 'tenant-update-stack', {
+//   tenantMappingTable: coreAppPlaneStack.tenantMappingTable,
+//   codeCommitRepositoryName: codeCommitRepositoryName,
+//   env: {
+//     account: process.env.CDK_DEFAULT_ACCOUNT,
+//     region: process.env.CDK_DEFAULT_REGION
+//   }
+// });
+// cdk.Aspects.of(ecsSaaSPipeline).add(new DestroyPolicySetter());

--- a/server/lib/shared-infra/shared-infra-stack.ts
+++ b/server/lib/shared-infra/shared-infra-stack.ts
@@ -3,7 +3,7 @@ import * as path from 'path';
 import * as elbv2 from 'aws-cdk-lib/aws-elasticloadbalancingv2';
 import * as targets from 'aws-cdk-lib/aws-elasticloadbalancingv2-targets';
 import { type Construct } from 'constructs';
-import { Stack, type StackProps, type Environment, Tags, CfnOutput } from 'aws-cdk-lib';
+import { Stack, type StackProps, type Environment, Tags, Fn, CfnOutput } from 'aws-cdk-lib';
 import { StringParameter } from 'aws-cdk-lib/aws-ssm';
 import { ApiGateway } from './api-gateway';
 import { type ApiKeySSMParameterNames } from '../interfaces/api-key-ssm-parameter-names';
@@ -34,10 +34,16 @@ export class SharedInfraStack extends Stack {
   constructor (scope: Construct, id: string, props: SharedInfraProps) {
     super(scope, id);
 
+    const azs = Fn.getAzs(this.region);
     this.vpc = new ec2.Vpc(this, 'sbt-ecs-vpc', {
       // maxAzs: 3,
       ipAddresses: ec2.IpAddresses.cidr('10.0.0.0/16'),
-      availabilityZones: [`${props.env.region}a`, `${props.env.region}b`, `${props.env.region}c`],
+      // availabilityZones: [`${props.env.region}a`, `${props.env.region}b`, `${props.env.region}c`],
+      availabilityZones: [
+        Fn.select(0, azs),
+        Fn.select(1, azs),
+        Fn.select(2, azs),
+      ],
       flowLogs: {
         'sbt-ecs-vpcFlowLog': {
           destination: ec2.FlowLogDestination.toCloudWatchLogs(),
@@ -166,6 +172,20 @@ export class SharedInfraStack extends Stack {
     new CfnOutput(this, 'EcsVpcId', {
       value: this.vpc.vpcId,
       exportName: 'EcsVpcId'
+    });
+
+
+    new CfnOutput(this, 'az1', {
+      value: this.vpc.availabilityZones[0],
+      exportName: 'az1'
+    });
+    new CfnOutput(this, 'az2', {
+      value: this.vpc.availabilityZones[1],
+      exportName: 'az2'
+    });
+    new CfnOutput(this, 'az3', {
+      value: this.vpc.availabilityZones[2],
+      exportName: 'az3'
     });
 
     new CfnOutput(this, 'PrivSubId1EcsSbt', {

--- a/server/lib/shared-infra/shared-infra-stack.ts
+++ b/server/lib/shared-infra/shared-infra-stack.ts
@@ -38,7 +38,6 @@ export class SharedInfraStack extends Stack {
     this.vpc = new ec2.Vpc(this, 'sbt-ecs-vpc', {
       // maxAzs: 3,
       ipAddresses: ec2.IpAddresses.cidr('10.0.0.0/16'),
-      // availabilityZones: [`${props.env.region}a`, `${props.env.region}b`, `${props.env.region}c`],
       availabilityZones: [
         Fn.select(0, azs),
         Fn.select(1, azs),

--- a/server/lib/tenant-template/ecs-cluster.ts
+++ b/server/lib/tenant-template/ecs-cluster.ts
@@ -45,7 +45,6 @@ export class EcsCluster extends cdk.NestedStack {
     this.isEc2Tier = props.isEc2Tier;
   
     this.vpc = ec2.Vpc.fromVpcAttributes(this, 'Vpc', {
-      // availabilityZones: [`${props.env.region}a`, `${props.env.region}b`, `${props.env.region}c`],
       availabilityZones: [
         cdk.Fn.importValue('az1'),
         cdk.Fn.importValue('az2'),
@@ -106,8 +105,7 @@ export class EcsCluster extends cdk.NestedStack {
       clusterName = `${props.stageName}-advanced-${cdk.Stack.of(this).account}`
     }
 
-    if('advanced' !== props.tier.toLocaleLowerCase() || 'ACTIVE' !== props.advancedCluster ) {
-      // console.error('No Cluster Found -->', this.cluster);    
+    if('advanced' !== props.tier.toLocaleLowerCase() || 'ACTIVE' !== props.advancedCluster ) {  
       this.cluster = new ecs.Cluster(this, 'EcsCluster', {
         clusterName,
         vpc: this.vpc,

--- a/server/lib/tenant-template/ecs-cluster.ts
+++ b/server/lib/tenant-template/ecs-cluster.ts
@@ -45,7 +45,12 @@ export class EcsCluster extends cdk.NestedStack {
     this.isEc2Tier = props.isEc2Tier;
   
     this.vpc = ec2.Vpc.fromVpcAttributes(this, 'Vpc', {
-      availabilityZones: [`${props.env.region}a`, `${props.env.region}b`, `${props.env.region}c`],
+      // availabilityZones: [`${props.env.region}a`, `${props.env.region}b`, `${props.env.region}c`],
+      availabilityZones: [
+        cdk.Fn.importValue('az1'),
+        cdk.Fn.importValue('az2'),
+        cdk.Fn.importValue('az3')
+      ],
       privateSubnetIds: [
         cdk.Fn.importValue('PrivSubId1EcsSbt'),
         cdk.Fn.importValue('PrivSubId2EcsSbt'),


### PR DESCRIPTION
*Issue #12 , if available:*
Unsupported Availability Zone was chosen. (ex. Tokyo region is not support b' AZ)

*Description of changes:*
Dynamically get Availability Zones using api "cdk.Fn.select"


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
