### PR TITLE
feat: AZ count setting and Shorten ECS Service name

### DIFF
--- a/client/AdminWeb/src/app/auth-config.module.ts
+++ b/client/AdminWeb/src/app/auth-config.module.ts
@@ -13,7 +13,7 @@ import { environment } from 'src/environments/environment';
         postLogoutRedirectUri: window.location.origin,
         redirectUrl: window.location.origin,
         responseType: 'code',
-        scope: 'openid profile email',
+        scope: 'openid profile email tenant/tenant_read tenant/tenant_write user/user_read user/user_write',
       },
     }),
   ],

--- a/client/AdminWeb/src/app/auth.interceptor.ts
+++ b/client/AdminWeb/src/app/auth.interceptor.ts
@@ -29,7 +29,7 @@ export class AuthInterceptor implements HttpInterceptor {
       return next.handle(req);
     }
 
-    return this.service.getIdToken().pipe(
+    return this.service.getAccessToken().pipe(
       switchMap((tok) => {
         req = req.clone({
           headers: req.headers.set('Authorization', 'Bearer ' + tok),

--- a/server/bin/ecs-saas-ref-template.ts
+++ b/server/bin/ecs-saas-ref-template.ts
@@ -3,7 +3,6 @@ import * as cdk from 'aws-cdk-lib';
 import { TenantTemplateStack } from '../lib/tenant-template/tenant-template-stack';
 import { DestroyPolicySetter } from '../lib/utilities/destroy-policy-setter';
 import { CoreAppPlaneStack } from '../lib/bootstrap-template/core-appplane-stack';
-import { TenantUpdatePipeline } from '../lib/tenant-template/tenant-update-stack';
 import { getEnv } from '../lib/utilities/helper-functions';
 import { ControlPlaneStack } from '../lib/bootstrap-template/control-plane-stack';
 import { SharedInfraStack } from '../lib/shared-infra/shared-infra-stack';
@@ -24,7 +23,6 @@ const basicId = 'basic';
 // required input parameters
 const systemAdminEmail = process.env.CDK_PARAM_SYSTEM_ADMIN_EMAIL;
 const tenantId = process.env.CDK_PARAM_TENANT_ID || basicId;
-const codeCommitRepositoryName = getEnv('CDK_PARAM_CODE_COMMIT_REPOSITORY_NAME');
 
 const commitId = getEnv('CDK_PARAM_COMMIT_ID');
 const tier = getEnv('CDK_PARAM_TIER');

--- a/server/bin/ecs-saas-ref-template.ts
+++ b/server/bin/ecs-saas-ref-template.ts
@@ -114,6 +114,7 @@ const sharedInfraStack = new SharedInfraStack(app, 'shared-infra-stack', {
   isPooledDeploy: isPooledDeploy,
   ApiKeySSMParameterNames: apiKeySSMParameterNames,
   stageName: stageName,
+  azCount: 3,
   env: {
     account: process.env.CDK_DEFAULT_ACCOUNT,
     region: process.env.CDK_DEFAULT_REGION

--- a/server/bin/ecs-saas-ref-template.ts
+++ b/server/bin/ecs-saas-ref-template.ts
@@ -19,7 +19,7 @@ if (!process.env.CDK_PARAM_TENANT_ID) {
   console.log('Tenant ID is empty, a default tenant id "basic" will be assigned');
 }
 const basicId = 'basic';
-const AzCount = 2;
+const AzCount = 3;
 
 if(AzCount < 2) {
   throw new Error('Please Available Zones count must be at least 2');

--- a/server/bin/ecs-saas-ref-template.ts
+++ b/server/bin/ecs-saas-ref-template.ts
@@ -114,7 +114,7 @@ const sharedInfraStack = new SharedInfraStack(app, 'shared-infra-stack', {
   isPooledDeploy: isPooledDeploy,
   ApiKeySSMParameterNames: apiKeySSMParameterNames,
   stageName: stageName,
-  azCount: 3,
+  azCount: 2,
   env: {
     account: process.env.CDK_DEFAULT_ACCOUNT,
     region: process.env.CDK_DEFAULT_REGION

--- a/server/bin/ecs-saas-ref-template.ts
+++ b/server/bin/ecs-saas-ref-template.ts
@@ -21,8 +21,8 @@ if (!process.env.CDK_PARAM_TENANT_ID) {
 const basicId = 'basic';
 const AzCount = 3;
 
-if(AzCount < 2) {
-  throw new Error('Please Available Zones count must be at least 2');
+if(AzCount < 2 || AzCount > 3) {
+  throw new Error('Please Availability Zones count must be 2 or 3');
 }
 // required input parameters
 const systemAdminEmail = process.env.CDK_PARAM_SYSTEM_ADMIN_EMAIL;

--- a/server/bin/ecs-saas-ref-template.ts
+++ b/server/bin/ecs-saas-ref-template.ts
@@ -116,7 +116,7 @@ const controlPlaneStack = new ControlPlaneStack(app, 'controlplane-stack', {
 const coreAppPlaneStack = new CoreAppPlaneStack(app, 'core-appplane-stack', {
   systemAdminEmail: systemAdminEmail,
   regApiGatewayUrl: controlPlaneStack.regApiGatewayUrl,
-  eventBusArn: controlPlaneStack.eventBusArn,
+  eventManager: controlPlaneStack.eventManager,
   env: {
     account: process.env.CDK_DEFAULT_ACCOUNT,
     region: process.env.CDK_DEFAULT_REGION

--- a/server/lib/bootstrap-template/control-plane-stack.ts
+++ b/server/lib/bootstrap-template/control-plane-stack.ts
@@ -1,22 +1,20 @@
-import { Stack, type StackProps, CfnOutput } from 'aws-cdk-lib';
-import { type Construct } from 'constructs';
 import * as cdk from 'aws-cdk-lib';
-import * as control_plane from '@cdklabs/sbt-aws';
-import { CognitoAuth } from '@cdklabs/sbt-aws';
+import { type Construct } from 'constructs';
 import { StaticSiteDistro } from './static-site-distro';
 import path = require('path');
 import { StaticSite } from './static-site';
 import { ControlPlaneNag } from '../cdknag/control-plane-nag';
+import * as sbt from '@cdklabs/sbt-aws';
 
-interface ControlPlaneStackProps extends StackProps {
+interface ControlPlaneStackProps extends cdk.StackProps {
   systemAdminRoleName: string
   systemAdminEmail: string
 }
 
-export class ControlPlaneStack extends Stack {
+export class ControlPlaneStack extends cdk.Stack {
   public readonly regApiGatewayUrl: string;
   public readonly eventBusArn: string;
-  public readonly auth: CognitoAuth;
+  public readonly auth: sbt.CognitoAuth;
   public readonly adminSiteUrl: string;
   public readonly StaticSite: StaticSite;
 
@@ -37,13 +35,13 @@ export class ControlPlaneStack extends Stack {
 
     this.adminSiteUrl = `https://${distro.cloudfrontDistribution.domainName}`;
 
-    const cognitoAuth = new CognitoAuth(this, 'CognitoAuth', {
+    const cognitoAuth = new sbt.CognitoAuth(this, 'CognitoAuth', {
       systemAdminRoleName: props.systemAdminRoleName,
       systemAdminEmail: props.systemAdminEmail,
       controlPlaneCallbackURL: this.adminSiteUrl
     });
 
-    const controlPlane = new control_plane.ControlPlane(this, 'controlplane-sbt', {
+    const controlPlane = new sbt.ControlPlane(this, 'controlplane-sbt', {
       auth: cognitoAuth
     });
 
@@ -64,7 +62,7 @@ export class ControlPlaneStack extends Stack {
       accessLogsBucket
     });
 
-    new CfnOutput(this, 'adminSiteUrl', {
+    new cdk.CfnOutput(this, 'adminSiteUrl', {
       value: this.adminSiteUrl
     });
 

--- a/server/lib/bootstrap-template/core-appplane-stack.ts
+++ b/server/lib/bootstrap-template/core-appplane-stack.ts
@@ -4,18 +4,11 @@ import { Table, AttributeType } from 'aws-cdk-lib/aws-dynamodb';
 import { PolicyDocument } from 'aws-cdk-lib/aws-iam';
 import { EventBus } from 'aws-cdk-lib/aws-events';
 import * as fs from 'fs';
-import { type ApiKeySSMParameterNames } from '../interfaces/api-key-ssm-parameter-names';
-import { TenantApiKey } from './tenant-api-key';
 import { UserInterface } from './user-interface';
 import { CoreAppPlaneNag } from '../cdknag/core-app-plane-nag';
 import * as sbt from '@cdklabs/sbt-aws';
 
 interface CoreAppPlaneStackProps extends cdk.StackProps {
-  ApiKeySSMParameterNames: ApiKeySSMParameterNames
-  apiKeyPlatinumTierParameter: string
-  apiKeyPremiumTierParameter: string
-  apiKeyAdvancedTierParameter: string
-  apiKeyBasicTierParameter: string
   eventBusArn: string
   systemAdminEmail: string
   regApiGatewayUrl: string
@@ -110,30 +103,6 @@ export class CoreAppPlaneStack extends cdk.Stack {
     new sbt.CoreApplicationPlane(this, 'coreappplane-sbt', {
       eventManager: eventManager,
       jobRunnerPropsList: [provisioningJobRunnerProps, deprovisioningJobRunnerProps]
-    });
-
-    new TenantApiKey(this, 'BasicTierApiKey', {
-      apiKeyValue: props.apiKeyBasicTierParameter,
-      ssmParameterApiKeyIdName: props.ApiKeySSMParameterNames.basic.keyId,
-      ssmParameterApiValueName: props.ApiKeySSMParameterNames.basic.value
-    });
-
-    new TenantApiKey(this, 'AdvancedTierApiKey', {
-      apiKeyValue: props.apiKeyAdvancedTierParameter,
-      ssmParameterApiKeyIdName: props.ApiKeySSMParameterNames.advanced.keyId,
-      ssmParameterApiValueName: props.ApiKeySSMParameterNames.advanced.value
-    });
-
-    new TenantApiKey(this, 'PremiumTierApiKey', {
-      apiKeyValue: props.apiKeyPremiumTierParameter,
-      ssmParameterApiKeyIdName: props.ApiKeySSMParameterNames.premium.keyId,
-      ssmParameterApiValueName: props.ApiKeySSMParameterNames.premium.value
-    });
-
-    new TenantApiKey(this, 'PlatinumTierApiKey', {
-      apiKeyValue: props.apiKeyPlatinumTierParameter,
-      ssmParameterApiKeyIdName: props.ApiKeySSMParameterNames.platinum.keyId,
-      ssmParameterApiValueName: props.ApiKeySSMParameterNames.platinum.value
     });
 
     this.userInterface = new UserInterface(this, 'saas-application-ui', {

--- a/server/lib/cdknag/control-plane-nag.ts
+++ b/server/lib/cdknag/control-plane-nag.ts
@@ -33,9 +33,8 @@ export class ControlPlaneNag extends Construct {
     NagSuppressions.addResourceSuppressionsByPath(
       cdk.Stack.of(this),
       [
-        `${sbtPath}/controlplane-api-stack/controlPlaneAPI/EventsRole/DefaultPolicy/Resource`,
-        `${sbtPath}/services-stack/tenantManagementExecRole/DefaultPolicy/Resource`,
-        `${sbtPath}/auth-info-service-stack/TenantConfigServiceLambda/ServiceRole/DefaultPolicy/Resource`
+        `${sbtPath}/tenantManagementServicves/tenantManagementLambda/tenantManagementExecRole/DefaultPolicy/Resource`,
+        `${sbtPath}/tenantConfigService/tenantConfigLambda/TenantConfigServiceLambda/ServiceRole/DefaultPolicy/Resource`,
       ],
       [
         policy,
@@ -47,7 +46,7 @@ export class ControlPlaneNag extends Construct {
               regex: '/^Resource::arn:aws:execute-api:(.*):(.*)\\*$/g'
             },
             {
-              regex: '/^Resource::<controlplanesbttablesstackTenant(.*).Arn(.*)\\*$/g'
+              regex: '/^Resource::<controlplanesbttenantManagementServicves(.*).Arn(.*)\\*$/g'
             }
           ]
         }

--- a/server/lib/cdknag/core-app-plane-nag.ts
+++ b/server/lib/cdknag/core-app-plane-nag.ts
@@ -21,15 +21,14 @@ export class CoreAppPlaneNag extends Construct {
       ]
     };
 
-    const sbtNagPath = '/core-appplane-stack/coreappplane-sbt';
     const nagWebPath = '/core-appplane-stack/saas-application-ui/TenantWebUI';
     const nagStaticPath = '/core-appplane-stack/saas-application-ui/StaticSiteDistro';
 
     NagSuppressions.addResourceSuppressionsByPath(
       cdk.Stack.of(this),
       [
-        `${sbtNagPath}/provisioning-codeBuildProvisionProjectRole/Resource`,
-        `${sbtNagPath}/deprovisioning-codeBuildProvisionProjectRole/Resource`
+        'core-appplane-stack/provisioningJobRunner/codeBuildProvisionProjectRole/Resource',
+        'core-appplane-stack/deprovisioningJobRunner/codeBuildProvisionProjectRole/Resource'
       ],
       [
         {

--- a/server/lib/shared-infra/shared-infra-stack.ts
+++ b/server/lib/shared-infra/shared-infra-stack.ts
@@ -47,11 +47,11 @@ export class SharedInfraStack extends Stack {
 
     for (let i = 0; i < props.azCount; i++) {
       selectedAzs[i] = Fn.select(i, azs);
-      new CfnOutput(this, `az${i+1}`, {
-        value: Fn.select(i, azs),
-        description: `Availability Zone ${i+1}`,
-        exportName: `az${i+1}`
-      });
+      // new CfnOutput(this, `az${i+1}`, {
+      //   value: selectedAzs[i],
+      //   description: `Availability Zone ${i+1}`,
+      //   exportName: `az${i+1}`
+      // });
     }
    
 
@@ -77,10 +77,10 @@ export class SharedInfraStack extends Stack {
     this.vpc.privateSubnets.forEach((subnet, index) => {
       const cfnSubnet = subnet.node.defaultChild as ec2.CfnSubnet;
       cfnSubnet.addPropertyOverride('CidrBlock', `10.0.${index * 64}.0/18`);
-      new CfnOutput(this, `PrivSubId${index+1}EcsSbt`, {
-        value: this.vpc.privateSubnets[index].subnetId,
-        exportName: `PrivSubId${index+1}EcsSbt`
-      });
+      // new CfnOutput(this, `PrivSubId${index+1}EcsSbt`, {
+      //   value: this.vpc.privateSubnets[index].subnetId,
+      //   exportName: `PrivSubId${index+1}EcsSbt`
+      // });
       // new CfnOutput(this, `PrivSub${index+1}RouteId`, {
       //   value: this.vpc.privateSubnets[index].routeTable.routeTableId,
       //   exportName: `PrivSub${index+1}RouteId`
@@ -92,7 +92,8 @@ export class SharedInfraStack extends Stack {
       
     });
 
-    // new CfnOutput(this, 'PrivateSubnetIds', { value: this.vpc.privateSubnets.map(subnet => subnet.subnetId).join(',') });
+    new CfnOutput(this, 'PrivateSubnetIds', { value: this.vpc.privateSubnets.map(subnet => subnet.subnetId).join(','), exportName: 'PrivateSubnetIds' });
+    new CfnOutput(this, 'AvailabilityZones', { value: selectedAzs.join(','), exportName:'AvailabilityZones' });
 
     // new CfnOutput(this, 'VpcPublicSubnetIds', { value: this.vpc.publicSubnets.map(routeTable => routeTable.).join(',') });
 

--- a/server/lib/shared-infra/tenant-api-key.ts
+++ b/server/lib/shared-infra/tenant-api-key.ts
@@ -9,20 +9,23 @@ interface TenantApiKeyProps {
 }
 
 export class TenantApiKey extends Construct {
+  apiKey: ApiKey;
+  apiKeyValue: string;
   constructor (scope: Construct, id: string, props: TenantApiKeyProps) {
     super(scope, id);
+    this.apiKeyValue = props.apiKeyValue;
 
-    const apiKey = new ApiKey(this, 'apiKey', {
+    this.apiKey = new ApiKey(this, 'apiKey', {
       value: props.apiKeyValue
     });
     new StringParameter(this, 'apiKeyId', {
       parameterName: props.ssmParameterApiKeyIdName,
-      stringValue: apiKey.keyId
+      stringValue: this.apiKey.keyId
     });
 
     new StringParameter(this, 'apiKeyValue', {
       parameterName: props.ssmParameterApiValueName,
-      stringValue: props.apiKeyValue
+      stringValue: this.apiKeyValue
     });
   }
 }

--- a/server/lib/tenant-template/ecs-cluster.ts
+++ b/server/lib/tenant-template/ecs-cluster.ts
@@ -46,17 +46,18 @@ export class EcsCluster extends cdk.NestedStack {
   
     this.vpc = ec2.Vpc.fromVpcAttributes(this, 'Vpc', {
       vpcId: cdk.Fn.importValue('EcsVpcId'),
-      availabilityZones: [
-        cdk.Fn.importValue('az1'),
-        cdk.Fn.importValue('az2'),
-        cdk.Fn.importValue('az3')
-      ],
-      // privateSubnetIds : cdk.Fn.split(',', cdk.Fn.importValue('PrivateSubnetIds')).map(subnetId => cdk.Fn.select(1, cdk.Fn.split('/', subnetId)))
-      privateSubnetIds: [
-        cdk.Fn.importValue('PrivSubId1EcsSbt'),
-        cdk.Fn.importValue('PrivSubId2EcsSbt'),
-        cdk.Fn.importValue('PrivSubId3EcsSbt')
-      ],
+      availabilityZones: cdk.Fn.split(',', cdk.Fn.importValue('AvailabilityZones')),
+      // [
+      //   cdk.Fn.importValue('az1'),
+      //   cdk.Fn.importValue('az2'),
+      //   cdk.Fn.importValue('az3')
+      // ],
+      privateSubnetIds : cdk.Fn.split(',', cdk.Fn.importValue('PrivateSubnetIds'))
+      // privateSubnetIds: [
+      //   cdk.Fn.importValue('PrivSubId1EcsSbt'),
+      //   cdk.Fn.importValue('PrivSubId2EcsSbt'),
+      //   cdk.Fn.importValue('PrivSubId3EcsSbt')
+      // ],
       // privateSubnetRouteTableIds: [
       //   cdk.Fn.importValue('PrivSub1RouteId'),
       //   cdk.Fn.importValue('PrivSub2RouteId'),

--- a/server/lib/tenant-template/ecs-cluster.ts
+++ b/server/lib/tenant-template/ecs-cluster.ts
@@ -277,9 +277,10 @@ export class EcsCluster extends cdk.NestedStack {
         service = new ecs.FargateService(this, `${info.name}-service`, serviceProps);
       }
 
+      const alphaNumericTenantId = `${tenantId}`.replace(/[^a-zA-Z0-9]/g, '');
       const cfnService = service.node.defaultChild as ecs.CfnService;
-      cfnService.overrideLogicalId(`${info.name}${tenantId}`);
-      cfnService.serviceName = `${info.name}-${tenantId}`;
+      cfnService.overrideLogicalId(`${info.name}${alphaNumericTenantId}`);
+      cfnService.serviceName = `${info.name}${alphaNumericTenantId}`;
 
       if (props.isRProxy) {
         rproxyService.node.addDependency(service);
@@ -402,9 +403,10 @@ export class EcsCluster extends cdk.NestedStack {
       service = new ecs.FargateService(this, `${info.name}-nginx`, serviceProps);
     }
 
+    const alphaNumericTenantId = `${tenantId}`.replace(/[^a-zA-Z0-9]/g, '');
     const cfnService = service.node.defaultChild as ecs.CfnService;
-    cfnService.overrideLogicalId(`${info.name}${tenantId}`);
-    cfnService.serviceName = `${info.name}-${tenantId}`;
+    cfnService.overrideLogicalId(`${info.name}${alphaNumericTenantId}`);
+    cfnService.serviceName = `${info.name}${alphaNumericTenantId}`;
 
     const targetGroupHttp = new elbv2.ApplicationTargetGroup(this, `target-group-${tenantId}`, {
       port: info.containerPort,

--- a/server/lib/tenant-template/ecs-cluster.ts
+++ b/server/lib/tenant-template/ecs-cluster.ts
@@ -45,22 +45,24 @@ export class EcsCluster extends cdk.NestedStack {
     this.isEc2Tier = props.isEc2Tier;
   
     this.vpc = ec2.Vpc.fromVpcAttributes(this, 'Vpc', {
+      vpcId: cdk.Fn.importValue('EcsVpcId'),
       availabilityZones: [
         cdk.Fn.importValue('az1'),
         cdk.Fn.importValue('az2'),
         cdk.Fn.importValue('az3')
       ],
+      // privateSubnetIds : cdk.Fn.split(',', cdk.Fn.importValue('PrivateSubnetIds')).map(subnetId => cdk.Fn.select(1, cdk.Fn.split('/', subnetId)))
       privateSubnetIds: [
         cdk.Fn.importValue('PrivSubId1EcsSbt'),
         cdk.Fn.importValue('PrivSubId2EcsSbt'),
         cdk.Fn.importValue('PrivSubId3EcsSbt')
       ],
-      privateSubnetRouteTableIds: [
-        cdk.Fn.importValue('PrivSub1RouteId'),
-        cdk.Fn.importValue('PrivSub2RouteId'),
-        cdk.Fn.importValue('PrivSub3RouteId')
-      ],
-      vpcId: cdk.Fn.importValue('EcsVpcId')
+      // privateSubnetRouteTableIds: [
+      //   cdk.Fn.importValue('PrivSub1RouteId'),
+      //   cdk.Fn.importValue('PrivSub2RouteId'),
+      //   cdk.Fn.importValue('PrivSub3RouteId')
+      // ],
+      
     });
 
     // alb Security Group ID

--- a/server/lib/tenant-template/ecs-cluster.ts
+++ b/server/lib/tenant-template/ecs-cluster.ts
@@ -131,11 +131,9 @@ export class EcsCluster extends cdk.NestedStack {
       }
     }  
 
-
     this.namespace = new HttpNamespace(this, 'CloudMapNamespace', {
       name: `ecs-sbt.local-${tenantId}`,
     });
-
 
     // Read JSON file with container info
     const containerInfoJSON = fs.readFileSync(path.resolve(__dirname, '../service-info.json'));
@@ -442,7 +440,6 @@ export class EcsCluster extends cdk.NestedStack {
     return service;
   }
 
-
   private getCluster (
     tier: string,
     stageName: string
@@ -455,7 +452,6 @@ export class EcsCluster extends cdk.NestedStack {
         vpc: this.vpc,
         securityGroups: [],
       });
-
     }
   
     return this.cluster;

--- a/server/lib/tenant-template/ecs-cluster.ts
+++ b/server/lib/tenant-template/ecs-cluster.ts
@@ -289,6 +289,10 @@ export class EcsCluster extends cdk.NestedStack {
         service = new ecs.FargateService(this, `${info.name}-service`, serviceProps);
       }
 
+      const cfnService = service.node.defaultChild as ecs.CfnService;
+      cfnService.overrideLogicalId(`${info.name}service`);
+      cfnService.serviceName = `${info.name}service`;
+
       if (props.isRProxy) {
         rproxyService.node.addDependency(service);
       } else {
@@ -409,6 +413,10 @@ export class EcsCluster extends cdk.NestedStack {
     } else {
       service = new ecs.FargateService(this, `${info.name}-nginx`, serviceProps);
     }
+
+    const cfnService = service.node.defaultChild as ecs.CfnService;
+    cfnService.overrideLogicalId(`${info.name}service`);
+    cfnService.serviceName = `${info.name}service`;
 
     const targetGroupHttp = new elbv2.ApplicationTargetGroup(this, `target-group-${tenantId}`, {
       port: info.containerPort,

--- a/server/lib/tenant-template/tenant-template-stack.ts
+++ b/server/lib/tenant-template/tenant-template-stack.ts
@@ -1,8 +1,8 @@
-import { Stack, type StackProps, CfnOutput } from 'aws-cdk-lib';
+import * as cdk from 'aws-cdk-lib';
 import { type Construct } from 'constructs';
+import { type Table } from 'aws-cdk-lib/aws-dynamodb';
 import { IdentityProvider } from './identity-provider';
 import { type ApiKeySSMParameterNames } from '../interfaces/api-key-ssm-parameter-names';
-import { type Table } from 'aws-cdk-lib/aws-dynamodb';
 import {
   AwsCustomResource,
   AwsCustomResourcePolicy,
@@ -11,7 +11,7 @@ import {
 import { EcsCluster } from './ecs-cluster';
 import { TenantInfraNag } from '../cdknag/tenant-infra-nag';
 
-interface TenantTemplateStackProps extends StackProps {
+interface TenantTemplateStackProps extends cdk.StackProps {
   stageName: string
   lambdaReserveConcurrency: number
   lambdaCanaryDeploymentPreference: string
@@ -26,7 +26,7 @@ interface TenantTemplateStackProps extends StackProps {
   appSiteUrl: string
 }
 
-export class TenantTemplateStack extends Stack {
+export class TenantTemplateStack extends cdk.Stack {
   productServiceUri: string;
   orderServiceUri: string;
 
@@ -70,7 +70,7 @@ export class TenantTemplateStack extends Stack {
           TableName: props.tenantMappingTable.tableName,
           Item: {
             tenantId: { S: props.tenantId },
-            stackName: { S: Stack.of(this).stackName },
+            stackName: { S: cdk.Stack.of(this).stackName },
             codeCommitId: { S: props.commitId },
             waveNumber: { S: waveNumber }
           }
@@ -106,11 +106,11 @@ export class TenantTemplateStack extends Stack {
       })
     });
 
-    new CfnOutput(this, 'TenantUserpoolId', {
+    new cdk.CfnOutput(this, 'TenantUserpoolId', {
       value: identityProvider.tenantUserPool.userPoolId
     });
 
-    new CfnOutput(this, 'UserPoolClientId', {
+    new cdk.CfnOutput(this, 'UserPoolClientId', {
       value: identityProvider.tenantUserPoolClient.userPoolClientId
     });
 

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -8,13 +8,10 @@
       "name": "ecs-saas-ref-template",
       "version": "0.1.0",
       "dependencies": {
-        "@aws-cdk/aws-lambda-python-alpha": "2.133.0-alpha.0",
-        "@cdklabs/sbt-aws": "^0.1.12",
-        "aws-cdk": "^2.127.0",
-        "aws-cdk-lib": "^2.114.0",
-        "cdk": "^2.118.0",
-        "constructs": "^10.0.0",
-        "package-lock-only": "^0.0.4"
+        "@aws-cdk/aws-lambda-python-alpha": "^2.140.0-alpha.0",
+        "@cdklabs/sbt-aws": "0.3.6",
+        "aws-cdk-lib": "^2.140.0",
+        "constructs": "^10.0.0"
       },
       "bin": {
         "ecs-saas-ref-template": "bin/ecs-saas-ref-template.js"
@@ -67,24 +64,24 @@
       }
     },
     "node_modules/@aws-cdk/aws-lambda-python-alpha": {
-      "version": "2.133.0-alpha.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-lambda-python-alpha/-/aws-lambda-python-alpha-2.133.0-alpha.0.tgz",
-      "integrity": "sha512-LUKLooGuTNvr0Ok+EhKjQKJTjMgELyGEio7y0PxQgtMLqgRwMTXpinENqWoISNVaM+lJvp/Lwm+73CZyeaDQRw==",
+      "version": "2.140.0-alpha.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-lambda-python-alpha/-/aws-lambda-python-alpha-2.140.0-alpha.0.tgz",
+      "integrity": "sha512-tJ4GK4fIGjfHEN38NTYnxiovCB7xoR4sZRQtN9XefzpJKKllKxYMXLMF1PRRiOpewLjEtgupN5JG8Kfl/SRxcQ==",
       "engines": {
         "node": ">= 14.15.0"
       },
       "peerDependencies": {
-        "aws-cdk-lib": "^2.133.0",
+        "aws-cdk-lib": "^2.140.0",
         "constructs": "^10.0.0"
       }
     },
     "node_modules/@babel/code-frame": {
-      "version": "7.24.2",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.24.2.tgz",
-      "integrity": "sha512-y5+tLQyV8pg3fsiln67BVLD1P13Eg4lh5RW9mF0zUuvLrv9uIQ4MCL+CRT+FTsBlBjcIan6PGsLcBN0m3ClUyQ==",
+      "version": "7.24.7",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.24.7.tgz",
+      "integrity": "sha512-BcYH1CVJBO9tvyIZ2jVeXgSIMvGZ2FDRvDdOIVQyuklNKSsx+eppDEBq/g47Ayw+RqNFE+URvOShmf+f/qwAlA==",
       "dev": true,
       "dependencies": {
-        "@babel/highlight": "^7.24.2",
+        "@babel/highlight": "^7.24.7",
         "picocolors": "^1.0.0"
       },
       "engines": {
@@ -92,21 +89,21 @@
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.22.20",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.22.20.tgz",
-      "integrity": "sha512-Y4OZ+ytlatR8AI+8KZfKuL5urKp7qey08ha31L8b3BwewJAoJamTzyvxPR/5D+KkdJCGPq/+8TukHBlY10FX9A==",
+      "version": "7.24.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.24.7.tgz",
+      "integrity": "sha512-rR+PBcQ1SMQDDyF6X0wxtG8QyLCgUB0eRAGguqRLfkCA87l7yAP7ehq8SNj96OOGTO8OBV70KhuFYcIkHXOg0w==",
       "dev": true,
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/highlight": {
-      "version": "7.24.2",
-      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.24.2.tgz",
-      "integrity": "sha512-Yac1ao4flkTxTteCDZLEvdxg2fZfz1v8M4QpaGypq/WPDqg3ijHYbDfs+LG5hvzSoqaSZ9/Z9lKSP3CjZjv+pA==",
+      "version": "7.24.7",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.24.7.tgz",
+      "integrity": "sha512-EStJpq4OuY8xYfhGVXngigBJRWxftKX9ksiGDnmlY3o7B/V7KIAc9X4oiK87uPJSc/vs5L869bem5fhZa8caZw==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-validator-identifier": "^7.22.20",
+        "@babel/helper-validator-identifier": "^7.24.7",
         "chalk": "^2.4.2",
         "js-tokens": "^4.0.0",
         "picocolors": "^1.0.0"
@@ -187,9 +184,9 @@
       }
     },
     "node_modules/@cdklabs/sbt-aws": {
-      "version": "0.1.12",
-      "resolved": "https://registry.npmjs.org/@cdklabs/sbt-aws/-/sbt-aws-0.1.12.tgz",
-      "integrity": "sha512-lo1QR51D1posAJ3HStYShBatEw6x9zwMUOOsIC/0jH/GFgCfoHTKdSFfG/ayQTyZhR0C4HQ7PgoFdlhNiFW1hg==",
+      "version": "0.3.6",
+      "resolved": "https://registry.npmjs.org/@cdklabs/sbt-aws/-/sbt-aws-0.3.6.tgz",
+      "integrity": "sha512-0S/xHgzqoYv5wFVGs29N+F0gMYK/jghlDU40XOh31NB2a4V8YuXJNDgdlNTi5hMZz2Fmcl14tP5oB0w5aty2Gw==",
       "dependencies": {
         "@aws-cdk/aws-kinesisfirehose-alpha": "2.140.0-alpha.0",
         "@aws-cdk/aws-kinesisfirehose-destinations-alpha": "2.140.0-alpha.0",
@@ -227,16 +224,6 @@
       },
       "engines": {
         "node": ">=12"
-      }
-    },
-    "node_modules/@cspotcode/source-map-support/node_modules/@jridgewell/trace-mapping": {
-      "version": "0.3.9",
-      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
-      "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
-      "dev": true,
-      "dependencies": {
-        "@jridgewell/resolve-uri": "^3.0.3",
-        "@jridgewell/sourcemap-codec": "^1.4.10"
       }
     },
     "node_modules/@jest/expect-utils": {
@@ -290,10 +277,20 @@
       }
     },
     "node_modules/@jridgewell/sourcemap-codec": {
-      "version": "1.4.15",
-      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.15.tgz",
-      "integrity": "sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.0.tgz",
+      "integrity": "sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ==",
       "dev": true
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+      "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.0.3",
+        "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
     },
     "node_modules/@sinclair/typebox": {
       "version": "0.27.8",
@@ -387,9 +384,9 @@
       "dev": true
     },
     "node_modules/acorn": {
-      "version": "8.11.3",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.11.3.tgz",
-      "integrity": "sha512-Y9rRfJG5jcKOE0CLisYbojUjIrIEE7AGMzA/Sm4BslANhbS+cDMpgBdcPT91oJ7OuJ9hYJBx59RjbhxVnrF8Xg==",
+      "version": "8.12.1",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.12.1.tgz",
+      "integrity": "sha512-tcpGyI9zbizT9JbV6oYE477V6mTlXvvi0T0G3SNIYE2apm/G5huBa1+K89VGeovbg+jycCrfhl3ADxErOuO6Jg==",
       "dev": true,
       "bin": {
         "acorn": "bin/acorn"
@@ -399,10 +396,13 @@
       }
     },
     "node_modules/acorn-walk": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.2.tgz",
-      "integrity": "sha512-cjkyv4OtNCIeqhHrfS81QWXoCBPExR/J62oyEqepVw8WaQeSqpW2uhuLPh1m9eWhDuOo/jUXVTlifvesOWp/4A==",
+      "version": "8.3.3",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.3.tgz",
+      "integrity": "sha512-MxXdReSRhGO7VlFe1bRG/oI7/mdLV9B9JJT0N8vZOhF7gFRR5l3M8W9G8JxmKV+JC5mGqJ0QvqfSOLsCPa4nUw==",
       "dev": true,
+      "dependencies": {
+        "acorn": "^8.11.0"
+      },
       "engines": {
         "node": ">=0.4.0"
       }
@@ -428,24 +428,10 @@
       "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
       "dev": true
     },
-    "node_modules/aws-cdk": {
-      "version": "2.135.0",
-      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.135.0.tgz",
-      "integrity": "sha512-id/kBxDvXQhcPYhkP/3fwhaKN0uD3raz1Z4RZcO9jJ4UoQV2RElQl+dYdmIrwNSoNVhtZeV1O4IdEtBHUhdShQ==",
-      "bin": {
-        "cdk": "bin/cdk"
-      },
-      "engines": {
-        "node": ">= 14.15.0"
-      },
-      "optionalDependencies": {
-        "fsevents": "2.3.2"
-      }
-    },
     "node_modules/aws-cdk-lib": {
-      "version": "2.146.0",
-      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.146.0.tgz",
-      "integrity": "sha512-W3F2zH+P7hUxmu2dlEKJBBi6Twc4//NsJJW00h2LN0dKU+2302QY8jR+P7jgEYzZ7U50phtH4zO6BPmJrhLVEg==",
+      "version": "2.149.0",
+      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.149.0.tgz",
+      "integrity": "sha512-bmbgnF2dEYlsZlVaNoSfcjyIUirnvmsvNXJwBMmUCZn2IZ+YWvkMv+rr4e/GO3gPKrdNzew1jNVvHSYxlun6rA==",
       "bundleDependencies": [
         "@balena/dockerignore",
         "case",
@@ -796,24 +782,10 @@
         "node": ">=8"
       }
     },
-    "node_modules/cdk": {
-      "version": "2.135.0",
-      "resolved": "https://registry.npmjs.org/cdk/-/cdk-2.135.0.tgz",
-      "integrity": "sha512-PGFg9VnjM6ovUK6PgcrzUdEBIAN3NicNCabk39a5tapBfsK+tVUOLpIbUMBxZ7ld9ipNr3g6D6Z5zz5jxXTJXA==",
-      "dependencies": {
-        "aws-cdk": "2.135.0"
-      },
-      "bin": {
-        "cdk": "bin/cdk"
-      },
-      "engines": {
-        "node": ">= 14.15.0"
-      }
-    },
     "node_modules/cdk-nag": {
-      "version": "2.28.80",
-      "resolved": "https://registry.npmjs.org/cdk-nag/-/cdk-nag-2.28.80.tgz",
-      "integrity": "sha512-0h6IMWF/ZcaQ6tr5cYHmg3rgyrc/3xRjzY3Fh7VxcROZz6U+bP/e0U761Gt+UWE0zzSBNl3sGap6kRwToYXewA==",
+      "version": "2.28.160",
+      "resolved": "https://registry.npmjs.org/cdk-nag/-/cdk-nag-2.28.160.tgz",
+      "integrity": "sha512-Bwx33izyzeraHf+qbVFnFgcayRIDN3DwXTXIrNrgiS4idUGqKtcM2QJtpvsoLkma411mwYoPmhT1cRu1YFxJAA==",
       "peerDependencies": {
         "aws-cdk-lib": "^2.116.0",
         "constructs": "^10.0.5"
@@ -1050,95 +1022,22 @@
       "dev": true
     },
     "node_modules/micromatch": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.5.tgz",
-      "integrity": "sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==",
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.7.tgz",
+      "integrity": "sha512-LPP/3KorzCwBxfeUuZmaR6bG2kdeHSbe0P2tY3FLRU4vYrjYz5hI4QZwV0njUx3jeuKe67YukQ1LSPZBKDqO/Q==",
       "dev": true,
       "dependencies": {
-        "braces": "^3.0.2",
+        "braces": "^3.0.3",
         "picomatch": "^2.3.1"
       },
       "engines": {
         "node": ">=8.6"
       }
     },
-    "node_modules/package-lock-only": {
-      "version": "0.0.4",
-      "resolved": "https://registry.npmjs.org/package-lock-only/-/package-lock-only-0.0.4.tgz",
-      "integrity": "sha512-fV1YHeTMWH5LKmdVqfWskm2/SG0iF2IrxJn3ziaPVx9CnpecGJzt8xXtLV+CYINENZwPFMtbxO5qupz0asNz1A==",
-      "hasInstallScript": true,
-      "dependencies": {
-        "chalk": "^2.4.1"
-      }
-    },
-    "node_modules/package-lock-only/node_modules/ansi-styles": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-      "dependencies": {
-        "color-convert": "^1.9.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/package-lock-only/node_modules/chalk": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-      "dependencies": {
-        "ansi-styles": "^3.2.1",
-        "escape-string-regexp": "^1.0.5",
-        "supports-color": "^5.3.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/package-lock-only/node_modules/color-convert": {
-      "version": "1.9.3",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-      "dependencies": {
-        "color-name": "1.1.3"
-      }
-    },
-    "node_modules/package-lock-only/node_modules/color-name": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw=="
-    },
-    "node_modules/package-lock-only/node_modules/escape-string-regexp": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
-      "engines": {
-        "node": ">=0.8.0"
-      }
-    },
-    "node_modules/package-lock-only/node_modules/has-flag": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-      "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/package-lock-only/node_modules/supports-color": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-      "dependencies": {
-        "has-flag": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/picocolors": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
-      "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.1.tgz",
+      "integrity": "sha512-anP1Z8qwhkbmu7MFP5iTt+wQKXgwzf7zTyGlcdzabySa9vd0Xt392U0rVmz9poOaBj0uHJKyyo9/upk0HrEQew==",
       "dev": true
     },
     "node_modules/picomatch": {
@@ -1180,9 +1079,9 @@
       }
     },
     "node_modules/react-is": {
-      "version": "18.2.0",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
-      "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==",
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
       "dev": true
     },
     "node_modules/slash": {

--- a/server/package.json
+++ b/server/package.json
@@ -16,12 +16,9 @@
     "typescript": "~5.1.3"
   },
   "dependencies": {
-    "@aws-cdk/aws-lambda-python-alpha": "2.133.0-alpha.0",
-    "@cdklabs/sbt-aws": "^0.1.12",
-    "aws-cdk": "^2.127.0",
-    "aws-cdk-lib": "^2.114.0",
-    "cdk": "^2.118.0",
-    "constructs": "^10.0.0",
-    "package-lock-only": "^0.0.4"
+    "@aws-cdk/aws-lambda-python-alpha": "^2.140.0-alpha.0",
+    "@cdklabs/sbt-aws": "0.3.6",
+    "aws-cdk-lib": "^2.140.0",
+    "constructs": "^10.0.0"
   }
 }


### PR DESCRIPTION
*Issue #, if available:*
*Reason for this change*
- Long ECS service name reduces readability.
- Some customer wanted to make it possible to set AZ count to cost less for test, etc.
- Stack order has been changed for provisioning to save future workshop time.
- SBT 0.3.6 version applied

*Description of changes*
- Shorten ECS service name
- Set Availability Zone's count 2 or 3 
- Shared stack put to first order.
- SBT authentication applied - Admin UI - Access token & API call permission added

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
