### PR TITLE
Fix deprovisioning job to successfully delete premium tenant

### DIFF
--- a/server/lib/bootstrap-template/core-appplane-stack.ts
+++ b/server/lib/bootstrap-template/core-appplane-stack.ts
@@ -81,7 +81,7 @@ export class CoreAppPlaneStack extends cdk.Stack {
 `)
       ),
       script: fs.readFileSync('../scripts/deprovision-tenant.sh', 'utf8'),
-      environmentStringVariablesFromIncomingEvent: ['tenantId'],
+      environmentStringVariablesFromIncomingEvent: ['tenantId', 'tier'],
       environmentVariablesToOutgoingEvent: ['tenantStatus'],
       outgoingEvent: sbt.DetailType.DEPROVISION_SUCCESS,
       incomingEvent: sbt.DetailType.OFFBOARDING_REQUEST,


### PR DESCRIPTION
*Issue #, if available:*
I have not created an issue, instead opening this pull request.
When I tried to delete a premium tenant, tenant stack was not successfully deleted. I think that this is due to empty tenant tier variable ($tier in build environment).
Below is part of build log.
```
An error occurred (ResourceNotFoundException) when calling the ListUsersInGroup operation: Group not found.
--
346 |  
347 | An error occurred (ResourceNotFoundException) when calling the DeleteGroup operation: Group not found.
348 | Deleted user group: 0c69b814-b0f5-42b0-a897-6d17e173f52d
349 | All users have been removed from the group and the group has been deleted.
350 | No items found with PartitionKey = 0c69b814-b0f5-42b0-a897-6d17e173f52d
351 | No items found with PartitionKey = 0c69b814-b0f5-42b0-a897-6d17e173f52d
```

It seems that this conditional statement was evaluated incorrectly.
https://github.com/aws-samples/saas-reference-architecture-ecs/blob/f541ce43cf64248248dba8fa878e8dee085baa03/scripts/deprovision-tenant.sh#L79

*Description of changes:*
I have added a tier variable to deprovisioning JobRunner props.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
