### PR TITLE
fix: EC2 Launch Template Adoption

### DIFF
--- a/server/lib/cdknag/tenant-template-nag.ts
+++ b/server/lib/cdknag/tenant-template-nag.ts
@@ -34,7 +34,6 @@ export class TenantTemplateNag extends Construct {
         }
       ]
     );
-
     NagSuppressions.addResourceSuppressionsByPath(
       cdk.Stack.of(this),
       [
@@ -50,7 +49,6 @@ export class TenantTemplateNag extends Construct {
         }
       ]
     );
-
     NagSuppressions.addResourceSuppressionsByPath(
       cdk.Stack.of(this),
       [`/tenant-template-stack-${props.tenantId}/AWS679f53fac002430cb0da5b7982bd2287/Resource`],
@@ -61,7 +59,6 @@ export class TenantTemplateNag extends Construct {
         }
       ]
     );
-
     if('advanced' !== props.tier.toLocaleLowerCase() || 'INACTIVE' === props.advancedCluster )
     if (props.isEc2Tier) {
       NagSuppressions.addResourceSuppressionsByPath(
@@ -95,7 +92,6 @@ export class TenantTemplateNag extends Construct {
           }
         ]
       );
-     
       NagSuppressions.addResourceSuppressionsByPath(
         cdk.Stack.of(this),
         [`${nagEcsPath}/EniTrunking/EC2Role/DefaultPolicy/Resource`],
@@ -107,23 +103,19 @@ export class TenantTemplateNag extends Construct {
           }
         ]
       );
-
-
-
-
-
-
       NagSuppressions.addResourceSuppressionsByPath(
         cdk.Stack.of(this),
         [
           `${nagPath}/ecs-autoscaleG-${props.tenantId}/DrainECSHook/Function/ServiceRole/Resource`,
+          `${nagEcsPath}/EcsCluster/launchTemplateRole/Resource`
         ],
         [
           {
             id: 'AwsSolutions-IAM4',
             reason: 'This is not related with SaaS itself: SBT-ECS SaaS',
             appliesTo: [
-              'Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole'
+              'Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole',
+              'Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AmazonEC2ContainerServiceforEC2Role'
             ]
           }
         ]
@@ -138,11 +130,9 @@ export class TenantTemplateNag extends Construct {
           }
         ]
       );
-      
-
       NagSuppressions.addResourceSuppressionsByPath(
         cdk.Stack.of(this),
-        [`${nagPath}/ecs-autoscaleG-${props.tenantId}/LaunchConfig`],
+        [`${nagPath}/ecs-autoscaleG-${props.tenantId}/ASG`],
         [
           {
             id: 'AwsSolutions-EC26',
@@ -150,7 +140,6 @@ export class TenantTemplateNag extends Construct {
           }
         ]
       );
-
       NagSuppressions.addResourceSuppressionsByPath(
         cdk.Stack.of(this),
         [`${nagPath}/ecs-autoscaleG-${props.tenantId}/ASG`],
@@ -161,7 +150,6 @@ export class TenantTemplateNag extends Construct {
           }
         ]
       );
-
       NagSuppressions.addResourceSuppressionsByPath(
         cdk.Stack.of(this),
         [

--- a/server/lib/tenant-template/tenant-template-stack.ts
+++ b/server/lib/tenant-template/tenant-template-stack.ts
@@ -99,11 +99,6 @@ export class TenantTemplateStack extends cdk.Stack {
         tenantId: props.tenantId,
         tier: props.tier,
         isEc2Tier,
-        isRProxy,
-        env: {
-          account: process.env.CDK_DEFAULT_ACCOUNT,
-          region: process.env.CDK_DEFAULT_REGION
-        }
       });
       this.cluster = ecsCluster.cluster;
     }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
EC2 was created using Launch Configuration before. Launch Configuration was deprecated from 1st Oct(https://docs.aws.amazon.com/autoscaling/ec2/userguide/create-launch-config.html).
It is fixed by using Launch Templete by guidance.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
