### PR TITLE
fix: add Fargate X86_64 runtimePlatform, cleanup remaining resources …

### DIFF
--- a/scripts/cleanup/cleanup.sh
+++ b/scripts/cleanup/cleanup.sh
@@ -301,3 +301,29 @@ for SERVICE in "${SERVICE_REPOS[@]}"; do
 done
 
 echo "$(date) cleanup completed!"
+
+# ---- Report remaining resources that may need manual cleanup ----
+echo ""
+echo "======================================================"
+echo " Remaining Resources Check"
+echo "======================================================"
+
+echo ""
+echo "[DynamoDB Tables]"
+aws dynamodb list-tables --query 'TableNames[*]' --output text --no-cli-pager 2>/dev/null | tr '\t' '\n' | grep -iE "tenant|saas|order|product" || echo "  (none found)"
+
+echo ""
+echo "[Secrets Manager]"
+aws secretsmanager list-secrets --query "SecretList[?contains(Name, 'rds_proxy_multitenant') || contains(Name, 'DBsecret') || contains(Name, 'RdsCluster')].Name" --output text --no-cli-pager 2>/dev/null | tr '\t' '\n' || echo "  (none found)"
+
+echo ""
+echo "[Cognito User Pools]"
+aws cognito-idp list-user-pools --max-results 60 --query "UserPools[].{Name:Name,Id:Id}" --output table --no-cli-pager 2>/dev/null || echo "  (none found)"
+
+echo ""
+echo "[ECR Repositories]"
+aws ecr describe-repositories --query "repositories[].repositoryName" --output text --no-cli-pager 2>/dev/null | tr '\t' '\n' || echo "  (none found)"
+
+echo ""
+echo "If any resources remain above, delete them manually."
+echo "======================================================"

--- a/server/lib/utilities/ecs-utils.ts
+++ b/server/lib/utilities/ecs-utils.ts
@@ -37,6 +37,10 @@ export function createTaskDefinition (
       ...baseProps,
       cpu: containerDef.cpu || 256,
       memoryLimitMiB: containerDef.memoryLimitMiB || 512,
+      runtimePlatform: {
+        cpuArchitecture: ecs.CpuArchitecture.X86_64,
+        operatingSystemFamily: ecs.OperatingSystemFamily.LINUX,
+      },
     });
   }
 };


### PR DESCRIPTION
…report

- ecs-utils.ts: explicit runtimePlatform X86_64/LINUX for Fargate tasks (Apple Silicon build compatibility)
- cleanup.sh: report remaining AWS resources after cleanup (DynamoDB, Secrets Manager, Cognito, ECR)

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
